### PR TITLE
chore(commitlint): commitlintの有効化

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,6 +1,6 @@
 {
   "hooks": {
     "pre-commit": "lint-staged",
-    "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    "commit-msg": "commitlint --config commitlint.config.json -e $GIT_PARAMS"
   }
 }

--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.1",
+  "language": "en-US",
+  "words": [
+    "commitlint",
+    "commitmsg",
+    "codecov"
+  ],
+  "flagWords": [
+      "hte"
+  ],
+  "ignoreWords": [],
+  "dictionaryDefinitions": [
+      {
+          "name": "cities",
+          "path": "./sampleDictionaries/cities.txt"
+      }
+  ],
+  "dictionaries": ["cities"],
+  "languageSettings": [
+      {
+          "languageId": "*",
+          "dictionaries": []
+      }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "build:watch": "yarn run build -- --watch",
     "clean": "rimraf ./lib",
     "cli": "node ./lib/cli.js",
-    "commitlint": "commitlint",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "cruiser": "dependency-cruiser --validate .dependency-cruiser.json src",
     "format": "prettier --config .prettierrc --write src/*.{ts,tsx}",


### PR DESCRIPTION
## これはなに

* [x] commilintが有効になっていなかった


## どのように解決するか

* `.husky`の`commit-msg`でconfigを指定するようにした

```
"commit-msg": "commitlint --config commitlint.config.json -e $GIT_PARAMS"
```

## 確認事項

* [ ] 自己レビューした
* [ ] CIが通った

## バージョン

* [ ] Major: 後方互換性のない変更を含む
* [ ] Minor: 後方互換性があり機能を追加した
* [ ] Patch: 後方互換性があり、新規実装を含まないバグ修正を行った

Ref: [セマンティック バージョニング](https://semver.org/lang/ja/)

